### PR TITLE
changing grammar so that it can parse expect exprs and assignments

### DIFF
--- a/corpus/expressions.txt
+++ b/corpus/expressions.txt
@@ -25,3 +25,20 @@ sum(1, 2)
 		(call_suffix (value_arguments
 			(value_argument (integer_literal))
 			(value_argument (integer_literal))))))
+
+==================
+Expect expressions
+==================
+
+expect(1)
+
+---
+
+(source_file
+  (expect_expression
+    (call_suffix
+      (value_arguments
+        (value_argument
+          (integer_literal))))))
+
+

--- a/corpus/statements.txt
+++ b/corpus/statements.txt
@@ -12,3 +12,22 @@ for (value in values) {}
 		(simple_identifier)
 		(control_structure_body)))
 
+==================
+Assignments
+==================
+
+var sum = 1
+sum = 3
+
+---
+
+(source_file
+  (property_declaration
+    (variable_declaration
+      (simple_identifier))
+    (integer_literal))
+  (assignment
+    (directly_assignable_expression
+      (simple_identifier))
+    (integer_literal)))
+

--- a/grammar.js
+++ b/grammar.js
@@ -507,7 +507,7 @@ module.exports = grammar({
 		
 		assignment: $ => choice(
 			prec.left(PREC.ASSIGNMENT, seq($.directly_assignable_expression, $._assignment_and_operator, $._expression)),
-			// TODO
+			prec.left(PREC.ASSIGNMENT, seq($.directly_assignable_expression, "=", $._expression))
 		),
 		
 		// ==========
@@ -823,7 +823,7 @@ module.exports = grammar({
 			choice($.simple_identifier, "class")
 		),
 
-		_assignment_and_operator: $ => choice("+=", "-=", "*=", "/=", "%=", "="),
+		_assignment_and_operator: $ => choice("+=", "-=", "*=", "/=", "%="),
 		
 		_equality_operator: $ => choice("!=", "!==", "==", "==="),
 		

--- a/grammar.js
+++ b/grammar.js
@@ -41,6 +41,7 @@ const PREC = {
 	CONJUNCTION: 4,
 	DISJUNCTION: 3,
 	SPREAD: 2,
+	EXPECT: 2,
 	ASSIGNMENT: 1,
 	BLOCK: 1,
 	LAMBDA_LITERAL: 0,
@@ -528,7 +529,8 @@ module.exports = grammar({
 			$.navigation_expression,
 			$.prefix_expression,
 			$.as_expression,
-			$.spread_expression
+			$.spread_expression,
+			$.expect_expression,
 		),
 
 		postfix_expression: $ => prec.left(PREC.POSTFIX, seq($._expression, $._postfix_unary_operator)),
@@ -549,6 +551,8 @@ module.exports = grammar({
 		as_expression: $ => prec.left(PREC.AS, seq($._expression, $._as_operator, $._type)),
 
 		spread_expression: $ => prec.left(PREC.SPREAD, seq("*", $._expression)),
+
+		expect_expression: $ => prec.left(PREC.EXPECT, seq("expect", $.call_suffix)),
 
 		// Binary expressions
 
@@ -819,7 +823,7 @@ module.exports = grammar({
 			choice($.simple_identifier, "class")
 		),
 
-		_assignment_and_operator: $ => choice("+=", "-=", "*=", "/=", "%="),
+		_assignment_and_operator: $ => choice("+=", "-=", "*=", "/=", "%=", "="),
 		
 		_equality_operator: $ => choice("!=", "!==", "==", "==="),
 		

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -2594,6 +2594,27 @@
               }
             ]
           }
+        },
+        {
+          "type": "PREC_LEFT",
+          "value": 1,
+          "content": {
+            "type": "SEQ",
+            "members": [
+              {
+                "type": "SYMBOL",
+                "name": "directly_assignable_expression"
+              },
+              {
+                "type": "STRING",
+                "value": "="
+              },
+              {
+                "type": "SYMBOL",
+                "name": "_expression"
+              }
+            ]
+          }
         }
       ]
     },
@@ -4367,10 +4388,6 @@
         {
           "type": "STRING",
           "value": "%="
-        },
-        {
-          "type": "STRING",
-          "value": "="
         }
       ]
     },

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -2644,6 +2644,10 @@
         {
           "type": "SYMBOL",
           "name": "spread_expression"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "expect_expression"
         }
       ]
     },
@@ -2779,6 +2783,23 @@
           {
             "type": "SYMBOL",
             "name": "_expression"
+          }
+        ]
+      }
+    },
+    "expect_expression": {
+      "type": "PREC_LEFT",
+      "value": 2,
+      "content": {
+        "type": "SEQ",
+        "members": [
+          {
+            "type": "STRING",
+            "value": "expect"
+          },
+          {
+            "type": "SYMBOL",
+            "name": "call_suffix"
           }
         ]
       }
@@ -4346,6 +4367,10 @@
         {
           "type": "STRING",
           "value": "%="
+        },
+        {
+          "type": "STRING",
+          "value": "="
         }
       ]
     },

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -68,6 +68,10 @@
           "named": true
         },
         {
+          "type": "expect_expression",
+          "named": true
+        },
+        {
           "type": "hex_literal",
           "named": true
         },
@@ -315,6 +319,10 @@
           "named": true
         },
         {
+          "type": "expect_expression",
+          "named": true
+        },
+        {
           "type": "function_type",
           "named": true
         },
@@ -510,6 +518,10 @@
           "named": true
         },
         {
+          "type": "expect_expression",
+          "named": true
+        },
+        {
           "type": "hex_literal",
           "named": true
         },
@@ -687,6 +699,10 @@
         },
         {
           "type": "equality_expression",
+          "named": true
+        },
+        {
+          "type": "expect_expression",
           "named": true
         },
         {
@@ -944,6 +960,10 @@
         },
         {
           "type": "equality_expression",
+          "named": true
+        },
+        {
+          "type": "expect_expression",
           "named": true
         },
         {
@@ -1209,6 +1229,10 @@
           "named": true
         },
         {
+          "type": "expect_expression",
+          "named": true
+        },
+        {
           "type": "function_type",
           "named": true
         },
@@ -1401,6 +1425,10 @@
         },
         {
           "type": "equality_expression",
+          "named": true
+        },
+        {
+          "type": "expect_expression",
           "named": true
         },
         {
@@ -1602,6 +1630,10 @@
           "named": true
         },
         {
+          "type": "expect_expression",
+          "named": true
+        },
+        {
           "type": "hex_literal",
           "named": true
         },
@@ -1770,6 +1802,10 @@
         },
         {
           "type": "equality_expression",
+          "named": true
+        },
+        {
+          "type": "expect_expression",
           "named": true
         },
         {
@@ -1991,6 +2027,10 @@
         },
         {
           "type": "equality_expression",
+          "named": true
+        },
+        {
+          "type": "expect_expression",
           "named": true
         },
         {
@@ -2239,6 +2279,10 @@
           "named": true
         },
         {
+          "type": "expect_expression",
+          "named": true
+        },
+        {
           "type": "hex_literal",
           "named": true
         },
@@ -2414,6 +2458,10 @@
           "named": true
         },
         {
+          "type": "expect_expression",
+          "named": true
+        },
+        {
           "type": "hex_literal",
           "named": true
         },
@@ -2582,6 +2630,10 @@
         },
         {
           "type": "equality_expression",
+          "named": true
+        },
+        {
+          "type": "expect_expression",
           "named": true
         },
         {
@@ -2830,6 +2882,10 @@
           "named": true
         },
         {
+          "type": "expect_expression",
+          "named": true
+        },
+        {
           "type": "hex_literal",
           "named": true
         },
@@ -2933,6 +2989,21 @@
     }
   },
   {
+    "type": "expect_expression",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": false,
+      "required": true,
+      "types": [
+        {
+          "type": "call_suffix",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
     "type": "explicit_delegation",
     "named": true,
     "fields": {},
@@ -2998,6 +3069,10 @@
         },
         {
           "type": "equality_expression",
+          "named": true
+        },
+        {
+          "type": "expect_expression",
           "named": true
         },
         {
@@ -3222,6 +3297,10 @@
           "named": true
         },
         {
+          "type": "expect_expression",
+          "named": true
+        },
+        {
           "type": "hex_literal",
           "named": true
         },
@@ -3397,6 +3476,10 @@
           "named": true
         },
         {
+          "type": "expect_expression",
+          "named": true
+        },
+        {
           "type": "hex_literal",
           "named": true
         },
@@ -3569,6 +3652,10 @@
         },
         {
           "type": "equality_expression",
+          "named": true
+        },
+        {
+          "type": "expect_expression",
           "named": true
         },
         {
@@ -3924,6 +4011,10 @@
           "named": true
         },
         {
+          "type": "expect_expression",
+          "named": true
+        },
+        {
           "type": "hex_literal",
           "named": true
         },
@@ -4129,6 +4220,10 @@
           "named": true
         },
         {
+          "type": "expect_expression",
+          "named": true
+        },
+        {
           "type": "hex_literal",
           "named": true
         },
@@ -4304,6 +4399,10 @@
           "named": true
         },
         {
+          "type": "expect_expression",
+          "named": true
+        },
+        {
           "type": "hex_literal",
           "named": true
         },
@@ -4472,6 +4571,10 @@
         },
         {
           "type": "equality_expression",
+          "named": true
+        },
+        {
+          "type": "expect_expression",
           "named": true
         },
         {
@@ -4651,6 +4754,10 @@
           "named": true
         },
         {
+          "type": "expect_expression",
+          "named": true
+        },
+        {
           "type": "hex_literal",
           "named": true
         },
@@ -4824,6 +4931,10 @@
         },
         {
           "type": "equality_expression",
+          "named": true
+        },
+        {
+          "type": "expect_expression",
           "named": true
         },
         {
@@ -5145,6 +5256,10 @@
           "named": true
         },
         {
+          "type": "expect_expression",
+          "named": true
+        },
+        {
           "type": "hex_literal",
           "named": true
         },
@@ -5313,6 +5428,10 @@
         },
         {
           "type": "equality_expression",
+          "named": true
+        },
+        {
+          "type": "expect_expression",
           "named": true
         },
         {
@@ -5688,6 +5807,10 @@
           "named": true
         },
         {
+          "type": "expect_expression",
+          "named": true
+        },
+        {
           "type": "hex_literal",
           "named": true
         },
@@ -5914,6 +6037,10 @@
           "named": true
         },
         {
+          "type": "expect_expression",
+          "named": true
+        },
+        {
           "type": "hex_literal",
           "named": true
         },
@@ -6086,6 +6213,10 @@
         },
         {
           "type": "equality_expression",
+          "named": true
+        },
+        {
+          "type": "expect_expression",
           "named": true
         },
         {
@@ -6280,6 +6411,10 @@
         },
         {
           "type": "equality_expression",
+          "named": true
+        },
+        {
+          "type": "expect_expression",
           "named": true
         },
         {
@@ -6482,6 +6617,10 @@
           "named": true
         },
         {
+          "type": "expect_expression",
+          "named": true
+        },
+        {
           "type": "hex_literal",
           "named": true
         },
@@ -6653,6 +6792,10 @@
           "named": true
         },
         {
+          "type": "expect_expression",
+          "named": true
+        },
+        {
           "type": "hex_literal",
           "named": true
         },
@@ -6821,6 +6964,10 @@
         },
         {
           "type": "equality_expression",
+          "named": true
+        },
+        {
+          "type": "expect_expression",
           "named": true
         },
         {
@@ -6996,6 +7143,10 @@
         },
         {
           "type": "equality_expression",
+          "named": true
+        },
+        {
+          "type": "expect_expression",
           "named": true
         },
         {
@@ -7251,6 +7402,10 @@
           "named": true
         },
         {
+          "type": "expect_expression",
+          "named": true
+        },
+        {
           "type": "file_annotation",
           "named": true
         },
@@ -7466,6 +7621,10 @@
           "named": true
         },
         {
+          "type": "expect_expression",
+          "named": true
+        },
+        {
           "type": "hex_literal",
           "named": true
         },
@@ -7650,6 +7809,10 @@
         },
         {
           "type": "equality_expression",
+          "named": true
+        },
+        {
+          "type": "expect_expression",
           "named": true
         },
         {
@@ -8136,6 +8299,10 @@
           "named": true
         },
         {
+          "type": "expect_expression",
+          "named": true
+        },
+        {
           "type": "hex_literal",
           "named": true
         },
@@ -8355,6 +8522,10 @@
         },
         {
           "type": "equality_expression",
+          "named": true
+        },
+        {
+          "type": "expect_expression",
           "named": true
         },
         {
@@ -8589,6 +8760,10 @@
           "named": true
         },
         {
+          "type": "expect_expression",
+          "named": true
+        },
+        {
           "type": "hex_literal",
           "named": true
         },
@@ -8810,6 +8985,10 @@
           "named": true
         },
         {
+          "type": "expect_expression",
+          "named": true
+        },
+        {
           "type": "hex_literal",
           "named": true
         },
@@ -8986,6 +9165,10 @@
         },
         {
           "type": "equality_expression",
+          "named": true
+        },
+        {
+          "type": "expect_expression",
           "named": true
         },
         {


### PR DESCRIPTION
Using Martin's _make test_ csv that ranks the parsing errors in order of most-occurring to least-occurring, I found that:
1. `expect(<int>)` was unable to be parsed, with 1490 errors
2. `sum = 1` was unable to be parsed, with 1424 errors

As a result, I'm attempting to expand the tree-sitter grammar to parse these.

_Test Plan:_
Run 
`npx tree-sitter generate`
And 
`npx tree-sitter test`