### PR TITLE
fix func return parsing

### DIFF
--- a/corpus/misc_return_statement.txt
+++ b/corpus/misc_return_statement.txt
@@ -1,0 +1,22 @@
+==================
+Return Statement
+==================
+
+fun foo(p0:Int) {
+    return p0
+}
+
+
+---
+
+(source_file
+  (function_declaration
+    (simple_identifier)
+    (parameter
+      (simple_identifier)
+      (user_type
+        (type_identifier)))
+    (function_body
+      (statements
+        (jump_expression
+          (simple_identifier))))))

--- a/grammar.js
+++ b/grammar.js
@@ -579,8 +579,6 @@ module.exports = grammar({
 
 		infix_expression: $ => prec.left(PREC.INFIX, seq($.range_expression, $.simple_identifier, $.range_expression)),
 
-		//infix_expression: $ => prec.left(PREC.INFIX, seq($._expression, $.simple_identifier, $._expression)),
-
 		elvis_expression: $ => prec.left(PREC.ELVIS, seq($.infix_expression, "?:", $.infix_expression)),
 
 		check_expression: $ => prec.left(PREC.CHECK, seq($._expression, choice($._in_operator, $._is_operator), $._expression)),

--- a/grammar.js
+++ b/grammar.js
@@ -577,9 +577,11 @@ module.exports = grammar({
 
 		range_expression: $ => prec.left(PREC.RANGE, seq($._expression, "..", $._expression)),
 
-		infix_expression: $ => prec.left(PREC.INFIX, seq($._expression, $.simple_identifier, $._expression)),
+		infix_expression: $ => prec.left(PREC.INFIX, seq($.range_expression, $.simple_identifier, $.range_expression)),
 
-		elvis_expression: $ => prec.left(PREC.ELVIS, seq($._expression, "?:", $._expression)),
+		//infix_expression: $ => prec.left(PREC.INFIX, seq($._expression, $.simple_identifier, $._expression)),
+
+		elvis_expression: $ => prec.left(PREC.ELVIS, seq($.infix_expression, "?:", $.infix_expression)),
 
 		check_expression: $ => prec.left(PREC.CHECK, seq($._expression, choice($._in_operator, $._is_operator), $._expression)),
 		


### PR DESCRIPTION
Fixes the error given on the tree-sitter `return` statement for code like:
```
 fun foo(p0:Int) {
     return p0
 }
```

This case had 956 counted errors in the parsing repositories we tested against, and was changed referencing https://kotlinlang.org/docs/reference/grammar.html#infixFunctionCall

_Test Plan:_
In `ocaml-tree-sitter-semgrep/lang`, run 
```
./test-lang kotlin
```

Check that the `misc_return_statement` case passes.