### PR TITLE
fix: don't put string contents in string end token

### DIFF
--- a/src/scanner.c
+++ b/src/scanner.c
@@ -197,8 +197,7 @@ static bool scan_string_content(TSLexer *lexer, Stack *stack) {
           mark_end(lexer);
           lexer->result_symbol = STRING_CONTENT;
           return true;
-        }
-        else {
+        } else {
           pop(stack);
           advance(lexer);
           mark_end(lexer);

--- a/src/scanner.c
+++ b/src/scanner.c
@@ -177,21 +177,6 @@ static bool scan_string_content(TSLexer *lexer, Stack *stack) {
           return true;
         }
 
-        /* This is so if we lex something like 
-           """foo"""
-              ^ 
-           where we are at the `f`, we should quit after
-           reading `foo`, and ascribe it to STRING_CONTENT.
-           
-           Then, we restart and try to read the end.
-           This is to prevent `foo` from being absorbed into
-           the STRING_END token.
-         */
-        if (has_content && lexer->lookahead == end_char) {
-          lexer->result_symbol = STRING_CONTENT;
-          return true;
-        }
-
         /* Since the string internals are all hidden in the syntax
            tree anyways, there's no point in going to the effort of 
            specifically separating the string end from string contents.
@@ -214,28 +199,11 @@ static bool scan_string_content(TSLexer *lexer, Stack *stack) {
           return true;
         }
         else {
-        if (has_content) {
-          mark_end(lexer);
-          lexer->result_symbol = STRING_CONTENT;
-          return true;
-        }
-        else {
           pop(stack);
           advance(lexer);
           mark_end(lexer);
           lexer->result_symbol = STRING_END;
           return true;
-        pop(stack);
-        advance(lexer);
-        mark_end(lexer);
-        lexer->result_symbol = STRING_END;
-        return true;
-          pop(stack);
-          advance(lexer);
-          mark_end(lexer);
-          lexer->result_symbol = STRING_END;
-          return true;
-        }
         }
       }
     }
@@ -375,6 +343,7 @@ bool scan_automatic_semicolon(TSLexer *lexer) {
 
   switch (lexer->lookahead) {
     case ',':
+    case '.':
     case ':':
     case '*':
     case '%':


### PR DESCRIPTION
My previous PR at https://github.com/fwcd/tree-sitter-kotlin/pull/76 made it such that we used different logic for string scanning. I remarked that 
> Since the string internals are all hidden in the syntax tree anyways, there's no point in going to the effort of 
specifically separating the string end from string contents. If we see a bunch of quotes in a row, then we just go until
they stop appearing, then stop lexing and call it the string's end.

This is not exactly true. I was under the impression because the `tree-sitter parse` output showed just a single node for `string_literal`, that it would all be subsumed under the same thing, and it wouldn't matter exactly where you called `STRING_END` or `STRING_CONTENT`.

However, in the grammar, we see that there are indeed `string_end` and `string_start` nodes, just hidden in the parse tree.

This was causing downward consumption errors for tools like Semgrep, however, which un-hide those nodes.

So I made this change, which correctly tries to attribute string contents to only the `STRING_CONTENT`, and not `STRING_END` nodes.

So now we properly get something like:
<img width="503" alt="image" src="https://user-images.githubusercontent.com/49291449/230195531-0ae9f1bc-8813-4922-8f02-dd2f5a9a9e30.png">

in the debug parsing output for a file 
```
val sha256Digest = "SHA256"
val md5Digest = """MD5"""
```