### PR TITLE
feat: allow call suffixes

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -696,6 +696,15 @@ module.exports = grammar({
       )
     )),
 
+    call_suffix_without_type_arguments: $ => prec.left(seq(
+      choice(
+        seq(optional($.value_arguments), $.annotated_lambda),
+        $.value_arguments
+      )
+    )),
+
+
+
     annotated_lambda: $ => seq(
       repeat($.annotation),
       optional($.label),
@@ -940,7 +949,8 @@ module.exports = grammar({
     _postfix_unary_suffix: $ => choice(
       $._postfix_unary_operator,
       $.navigation_suffix,
-      $.indexing_suffix
+      $.indexing_suffix,
+      $.call_suffix_without_type_arguments
     ),
 
     _postfix_unary_expression: $ => seq($._primary_expression, repeat($._postfix_unary_suffix)),

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -3402,6 +3402,45 @@
         ]
       }
     },
+    "call_suffix_without_type_arguments": {
+      "type": "PREC_LEFT",
+      "value": 0,
+      "content": {
+        "type": "SEQ",
+        "members": [
+          {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "SEQ",
+                "members": [
+                  {
+                    "type": "CHOICE",
+                    "members": [
+                      {
+                        "type": "SYMBOL",
+                        "name": "value_arguments"
+                      },
+                      {
+                        "type": "BLANK"
+                      }
+                    ]
+                  },
+                  {
+                    "type": "SYMBOL",
+                    "name": "annotated_lambda"
+                  }
+                ]
+              },
+              {
+                "type": "SYMBOL",
+                "name": "value_arguments"
+              }
+            ]
+          }
+        ]
+      }
+    },
     "annotated_lambda": {
       "type": "SEQ",
       "members": [
@@ -4854,6 +4893,10 @@
         {
           "type": "SYMBOL",
           "name": "indexing_suffix"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "call_suffix_without_type_arguments"
         }
       ]
     },

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -832,6 +832,25 @@
     }
   },
   {
+    "type": "call_suffix_without_type_arguments",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "annotated_lambda",
+          "named": true
+        },
+        {
+          "type": "value_arguments",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
     "type": "callable_reference",
     "named": true,
     "fields": {},
@@ -2220,6 +2239,10 @@
         },
         {
           "type": "boolean_literal",
+          "named": true
+        },
+        {
+          "type": "call_suffix_without_type_arguments",
           "named": true
         },
         {

--- a/test/corpus/assignment.txt
+++ b/test/corpus/assignment.txt
@@ -20,11 +20,11 @@ class Foo(){
         (variable_declaration
           (simple_identifier)))
       (secondary_constructor
-      (function_value_parameters
-        (parameter
-          (simple_identifier)
-          (user_type
-            (type_identifier))))
+        (function_value_parameters
+          (parameter
+            (simple_identifier)
+            (user_type
+              (type_identifier))))
         (statements
           (assignment
             (directly_assignable_expression
@@ -65,3 +65,28 @@ fun main(){
             (indexing_suffix
               (integer_literal)))
           (string_literal))))))
+
+================================================================================
+Call Assignment
+================================================================================
+
+foo() = 2
+foo().bar = 3
+
+--------------------------------------------------------------------------------
+
+(source_file
+  (assignment
+    (directly_assignable_expression
+      (simple_identifier)
+      (call_suffix_without_type_arguments
+        (value_arguments)))
+    (integer_literal))
+  (assignment
+    (directly_assignable_expression
+      (simple_identifier)
+      (call_suffix_without_type_arguments
+        (value_arguments))
+      (navigation_suffix
+        (simple_identifier)))
+    (integer_literal)))


### PR DESCRIPTION
## What:
This PR allows call suffixes to appear in assignment expressions, such as 
```
foo().bar = 3
```

Note that allowing call suffixes with type arguments (which look like `foo<T>(4)`) caused tests to fail, because of a known ambiguity between type arguments and comparison operations. To ensure this did not happen, I created a new nonterminal which is just call suffixes without type arguments, and only allowed those. For the ones with type arguments, we will need a more sophisticated solution.

## Test plan:
`make test`