### PR TITLE
fix: support calls in assignments

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -613,7 +613,6 @@ module.exports = grammar({
 
     _unary_expression: $ => choice(
       $.postfix_expression,
-      $.call_expression,
       $.indexing_expression,
       $.navigation_expression,
       $.prefix_expression,
@@ -729,6 +728,7 @@ module.exports = grammar({
       $.string_literal,
       $.callable_reference,
       $._function_literal,
+      $.call_expression,
       $.object_literal,
       $.collection_literal,
       $.this_expression,

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -2841,10 +2841,6 @@
         },
         {
           "type": "SYMBOL",
-          "name": "call_expression"
-        },
-        {
-          "type": "SYMBOL",
           "name": "indexing_expression"
         },
         {
@@ -3611,6 +3607,10 @@
         {
           "type": "SYMBOL",
           "name": "_function_literal"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "call_expression"
         },
         {
           "type": "SYMBOL",

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -2223,6 +2223,10 @@
           "named": true
         },
         {
+          "type": "call_expression",
+          "named": true
+        },
+        {
           "type": "callable_reference",
           "named": true
         },


### PR DESCRIPTION
In Kotlin, we can write code like:

```
package annotation.test

public object Test {
    fun f1(context : Context) {
        Foo(context).elem = var1
    }
}
```

where `Foo(context).elem = var1` assigns `var1` to an object constructed in that line.

More generally, the result of calls can be shared objects that we wish to assign to. Therefore, expressions that can be on the left hand of assignments (primary expressions) need to include calls.

Test plan: parse the example given